### PR TITLE
Fix third party import footer bug

### DIFF
--- a/base/genimport.go
+++ b/base/genimport.go
@@ -120,7 +120,7 @@ type mapdecl struct {
 func (gen *genimport) mapdecl(head, althead string) mapdecl {
 	var foot string
 	if gen.mode == ImSharedLib {
-		foot = "nil,"
+		foot = "nil"
 	} else if strings.IndexByte(althead, '%') < 0 {
 		head = althead
 	} else {
@@ -134,13 +134,16 @@ func (d *mapdecl) header() {
 		d.out.WriteString(d.head)
 		d.out.WriteByte('{')
 		d.head = ""
-		d.foot = "\n\t},"
+		d.foot = "\n\t}"
 	}
 }
 
-func (d *mapdecl) footer() {
+func (d *mapdecl) footer(more bool) {
 	if len(d.foot) != 0 {
 		d.out.WriteString(d.foot)
+		if more {
+			d.out.WriteString(", ")
+		}
 	}
 }
 
@@ -226,7 +229,7 @@ func (gen *genimport) writeBinds() {
 			}
 		}
 	}
-	d.footer()
+	d.footer(true)
 }
 
 func (gen *genimport) writeTypes() {
@@ -241,7 +244,7 @@ func (gen *genimport) writeTypes() {
 			}
 		}
 	}
-	d.footer()
+	d.footer(true)
 }
 
 func (gen *genimport) writeProxies() {
@@ -255,7 +258,7 @@ func (gen *genimport) writeProxies() {
 			}
 		}
 	}
-	d.footer()
+	d.footer(true)
 }
 
 func (gen *genimport) writeUntypeds() {
@@ -275,7 +278,7 @@ func (gen *genimport) writeUntypeds() {
 			}
 		}
 	}
-	d.footer()
+	d.footer(true)
 }
 
 func (gen *genimport) writeWrappers() {
@@ -302,7 +305,7 @@ func (gen *genimport) writeWrappers() {
 			}
 		}
 	}
-	d.footer()
+	d.footer(false)
 }
 
 func (gen *genimport) writeInterfaceProxies() {


### PR DESCRIPTION
# What this PR fixes

As of now, the import of at least some 3rd party packages is broken.  For example:

```
$ gomacro
// GOMACRO, an interactive Go interpreter with macros <https://github.com/cosmos72/gomacro>
// Copyright (C) 2017 Massimiliano Ghilardi
// License LGPL v3+: GNU Lesser GPL version 3 or later <https://gnu.org/licenses/lgpl>
// This is free software with ABSOLUTELY NO WARRANTY.
//
// Type :help for help
gomacro> import "gonum.org/v1/gonum/mat"
// debug: created file "/home/dwhitena/go/src/gomacro_imports/gonum.org/v1/gonum/mat/mat.go"...
// debug: compiling "/home/dwhitena/go/src/gomacro_imports/gonum.org/v1/gonum/mat/mat.go" ...
# gomacro_imports/gonum.org/v1/gonum/mat
./mat.go:178:1: syntax error: unexpected }, expecting expression
./mat.go:185:43: syntax error: unexpected int, expecting comma or )
repl.go:1:1: error executing "go build -buildmode=plugin" in directory "/home/dwhitena/go/src/gomacro_imports/gonum.org/v1/gonum/mat/": exit status 2
gomacro>
```

The reason for this that an extra comma is being added to the return in the generated `func Exports()` plugin wrapper:

```
func Exports() (map[string]Value, map[string]Type, map[string]Type, map[string]string, map[string][]string) {
        return map[string]Value{
                "Col":  ValueOf(mat.Col),
                "Cond": ValueOf(mat.Cond),
                "CondNorm":     ValueOf(mat.CondNorm),

                 ...

                "RowNonZeroDoer":       TypeOf((*RowNonZeroDoer)(nil)).Elem(),
                "RowViewer":    TypeOf((*RowViewer)(nil)).Elem(),
                "Symmetric":    TypeOf((*Symmetric)(nil)).Elem(),
                "Triangular":   TypeOf((*Triangular)(nil)).Elem(),
                "Unconjugator": TypeOf((*Unconjugator)(nil)).Elem(),
                "UntransposeBander":    TypeOf((*UntransposeBander)(nil)).Elem(),
                "UntransposeTrier":     TypeOf((*UntransposeTrier)(nil)).Elem(),
                "Untransposer": TypeOf((*Untransposer)(nil)).Elem(),
                "Vector":       TypeOf((*Vector)(nil)).Elem(),
        },map[string]string{
                "ConditionTolerance":   "float:10000000000000000",
        },nil,
}
```

# How this PR fixes it

This is fixed by removing the commas explicitly from the `foot` fields and using a `more` flag to specify whether more returns are expected.  If more are expected, the comma is inserted.

Now,

```
$ gomacro
// GOMACRO, an interactive Go interpreter with macros <https://github.com/cosmos72/gomacro>
// Copyright (C) 2017 Massimiliano Ghilardi
// License LGPL v3+: GNU Lesser GPL version 3 or later <https://gnu.org/licenses/lgpl>
// This is free software with ABSOLUTELY NO WARRANTY.
//
// Type :help for help
gomacro> import "gonum.org/v1/gonum/mat"
// debug: created file "/home/dwhitena/go/src/gomacro_imports/gonum.org/v1/gonum/mat/mat.go"...
// debug: compiling "/home/dwhitena/go/src/gomacro_imports/gonum.org/v1/gonum/mat/mat.go" ...
gomacro> a := mat.NewDense(0, 0, nil)   
gomacro>
```

# Side note

FYI, we are using gomacro in a refactor of the Go kernel for Jupyter (https://github.com/gopherdata/gophernotes).  Seems to be working quite well so far minus these issues around third party packages.  Thanks for the project.