### PR TITLE
update build tags for Mac for go1.10

### DIFF
--- a/base/plugin.go
+++ b/base/plugin.go
@@ -1,4 +1,4 @@
-// +build go1.8,linux,!android,!gccgo
+// +build go1.8,linux,!android,!gccgo go1.10,darwin,!gccgo
 
 /*
  * gomacro - A Go interpreter with Lisp-like macros

--- a/base/plugin_dummy.go
+++ b/base/plugin_dummy.go
@@ -1,4 +1,4 @@
-// +build !go1.8 !linux android gccgo
+// +build !go1.8,!linux !go1.10,darwin android gccgo
 
 /*
  * gomacro - A Go interpreter with Lisp-like macros


### PR DESCRIPTION
From the `go 1.10` [release notes](https://golang.org/doc/go1.10#compiler):

> plugin now works on […] darwin/amd64.