### PR TITLE
Handle list of directories in $GOPATH

### DIFF
--- a/base/paths/paths.go
+++ b/base/paths/paths.go
@@ -17,8 +17,10 @@
 package paths
 
 import (
+	"fmt"
 	"go/build"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -68,8 +70,20 @@ func Subdir(dirs ...string) string {
 	return strings.Join(dirs, "/")
 }
 
-var (
-	GoSrcDir = Subdir(build.Default.GOPATH, "src")
+func findGomacroDir() string {
+	pkg := filepath.Join("github.com", "cosmos72", "gomacro") // vendored copies of gomacro may need to change this
+	for _, dir := range filepath.SplitList(build.Default.GOPATH) {
+		path := filepath.Join(dir, "src", pkg)
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	fmt.Printf("// WARNING: could not find %q in $GOPATH\n", pkg)
+	return GoSrcDir
+}
 
-	GomacroDir = Subdir(GoSrcDir, "github.com", "cosmos72", "gomacro") // vendored copies of gomacro may need to change this
+var (
+	GoSrcDir = Subdir(filepath.SplitList(build.Default.GOPATH)[0], "src")
+
+	GomacroDir = findGomacroDir()
 )


### PR DESCRIPTION
When $GOPATH is a list of directories, e.g. colon separated on *nix,
both path.GoSrcDir and path.GomacroDir are set incorrectly.

GoSrcDir is used to place temporary files as a result of import
statements. If $GOPATH is a list of directories you end up with
erroneous directories like /a:/b:/c/src/gomacro_imports/{pkg} in the
filesystem.

GomacroDir is currently set to GoSrcDir/src/github.com/cosmos72/gomacro.
When $GOPATH is a list, that directory never exists. GomacroDir is used
to place temporary files (for importing purposes) in the same
directory of gomacro so that it can be recompiled to use new imports.

This diff sets GoSrcDir to the first directory in $GOPATH, and sets
GomacroDir to the correct directory by scanning $GOPATH. If gomacro
source code is not available, prints a warning and sets it to GoSrcDir.

I'm not strong about the GomacroDir behavior and previously had a panic
when gomacro source is not available. However, enforcing users to carry
gomacro source code is probably not desirable, especially for systems
that can handle imports via Go plugins, like Linux and Mac.

This diff fix all import modes except ImInception. The ImInception mode
blindly assumes the imported package's source code is in GoSrcDir as
opposed to scanning $GOPATH.

Closes #32