### PR TITLE
gomacro -g makes x_package.go files. Fixes #49

### DIFF
--- a/base/genimport/gogenerate.go
+++ b/base/genimport/gogenerate.go
@@ -1,0 +1,61 @@
+package genimport
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+var sep = string(os.PathSeparator)
+
+// GoGenerateMain allows gomacro to be run under
+// go generate. Use a go generate comment like
+//
+// `//go:generate gomacro -g` or
+// `//go:generate gomacro -g github.com/cosmos72/gomacro/classic`
+//
+// at the top of one of your package's .go files.
+// If omitted, the optional import path that
+// follows -g defaults to the current directory.
+//
+// When GoGenerateMain() is called,
+// arg may be length 0, in which case we guess at
+// the import path using the current working
+// directory. If arg[0] does hold a string, it
+// must give an import path. The new x_package.go
+// bindings are written back to the same package.
+func GoGenerateMain(arg []string, imp *Importer) error {
+	var pkgpath string
+	switch len(arg) {
+	case 0:
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("gomacro -g error trying to get current dir: '%v'", err)
+		}
+		gopath := os.Getenv("GOPATH")
+		prefix := gopath + sep + "src" + sep
+		if strings.HasPrefix(cwd, prefix) {
+			pkgpath = cwd[len(prefix):]
+		} else {
+			// guess it is after the first `src` in cwd,
+			// since traditionally all packages are
+			// after $GOPATH/src/
+			splt := strings.SplitN(cwd, sep+"src"+sep, 2)
+			if len(splt) > 1 {
+				pkgpath = splt[1]
+			} else {
+				return fmt.Errorf(
+					"error: under gomacro -g <import path>" +
+						" must specify import path" +
+						" as we could not guess it.")
+			}
+		}
+	case 1:
+		pkgpath = arg[0]
+	default:
+		return fmt.Errorf("error: extraneous argument(s) after gomacro -g: '%s'",
+			strings.Join(arg[1:], " "))
+	}
+	_, err := imp.ImportPackageOrError("_i", pkgpath)
+	return err
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	. "github.com/cosmos72/gomacro/base"
+	"github.com/cosmos72/gomacro/base/genimport"
 	"github.com/cosmos72/gomacro/base/inspect"
 	"github.com/cosmos72/gomacro/base/paths"
 	"github.com/cosmos72/gomacro/fast"
@@ -114,6 +115,8 @@ func (cmd *Cmd) Main(args []string) (err error) {
 		case "-x", "--exec":
 			clear |= OptMacroExpandOnly
 			set &^= OptMacroExpandOnly
+		case "-g", "--genimport":
+			return genimport.GoGenerateMain(args[1:], NewGlobals().Importer)
 		default:
 			arg := args[0]
 			if len(arg) > 0 && arg[0] == '-' {
@@ -148,6 +151,8 @@ func (cmd *Cmd) Usage() error {
     -c,   --collect          collect declarations and statements, to print them later
     -e,   --expr EXPR        evaluate expression
     -f,   --force-overwrite  option -w will overwrite existing files
+    -g,   --genimport <path> write x_package.go bindings for this Go import path
+                             (omit path to import current dir and write x_package.go here).
     -h,   --help             show this help and exit
     -i,   --repl             interactive. start a REPL after evaluating expression, files and dirs.
                              default: start a REPL only if no expressions, files or dirs are specified


### PR DESCRIPTION
This works if the binary package is already installed. If not we get this error.
~~~
~/go/src/github.com/cosmos72/gomacro/classic (generate) $ rm $GOPATH/pkg/darwin_amd64/github.com/cosmos72/gomacro/classic.a
~/go/src/github.com/cosmos72/gomacro/classic (generate) $ gomacro -g
error loading package "github.com/cosmos72/gomacro/classic" metadata, maybe you need to download (go get), compile (go build) and install (go install) it? can't find import: "github.com/cosmos72/gomacro/classic"
~/go/src/github.com/cosmos72/gomacro/classic (generate) $ go install
~/go/src/github.com/cosmos72/gomacro/classic (generate) $ gomacro -g
// warning: created file "/Users/jaten/go/src/github.com/cosmos72/gomacro/classic/x_package.go", recompile gomacro to use it
~/go/src/github.com/cosmos72/gomacro/classic (generate) $
~~~
To circumvent that we could do a source import instead of a binary import in this case. Using golang.org/x/tools/go/loader.
That would let the x_package.go generation succeed more often.
(example of loader use: https://github.com/glycerine/greenpack/blob/master/parse/getast.go#L53 )
Thoughts? Good/bad/impossible?