### PR TITLE
Update gomacro prompts

### DIFF
--- a/base/global.go
+++ b/base/global.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	r "reflect"
+	"runtime"
 	"strings"
 
 	"github.com/cosmos72/gomacro/base/reflect"
@@ -66,6 +67,9 @@ type Globals struct {
 	MacroChar    rune // prefix for macro-related keywords macro, quote, quasiquote, splice... The default is '~'
 	ReplCmdChar  byte // prefix for special REPL commands env, help, inspect, quit, unload... The default is ':'
 	Inspector    Inspector
+	GoVersion    string
+	GoOS         string
+	GoArch       string
 }
 
 func NewGlobals() *Globals {
@@ -86,11 +90,14 @@ func NewGlobals() *Globals {
 		Imports:      nil,
 		Declarations: nil,
 		Statements:   nil,
-		Prompt:       "gomacro> ",
+		Prompt:       "gomacro [In]: ",
 		GensymN:      0,
 		ParserMode:   0,
 		MacroChar:    '~',
 		ReplCmdChar:  ':', // Jupyter and gophernotes would probably set this to '%'
+		GoVersion:    runtime.Version(),
+		GoOS:         runtime.GOOS,
+		GoArch:       runtime.GOARCH,
 	}
 	g.Importer = genimport.DefaultImporter(&g.Output)
 	return g

--- a/base/read.go
+++ b/base/read.go
@@ -350,7 +350,7 @@ func ReadMultiline(in Readline, opts ReadOptions, prompt string) (src string, fi
 			m = mNormal
 		}
 		if optPrompt {
-			currPrompt = makeDots(9 + 2*paren)
+			currPrompt = makeDots(14 + 2*paren)
 		}
 	}
 	if err != nil {
@@ -413,7 +413,7 @@ func lastIsKeywordIgnoresNl(line []byte, first, last int) bool {
 
 func makeDots(count int) string {
 	const (
-		dots    = ". . . .                                                                                             "
+		dots    = "        ....:                                                                              "
 		spaces  = "                                                                                                    "
 		ndots   = len(dots)
 		nspaces = len(spaces)

--- a/classic/interpreter.go
+++ b/classic/interpreter.go
@@ -49,13 +49,13 @@ var historyfile = paths.Subdir(paths.UserHomeDir(), ".gomacro_history")
 func (ir *Interp) ReplStdin() {
 	g := ir.Globals
 	if g.Options&OptShowPrompt != 0 {
-		fmt.Fprintf(ir.Stdout, `// GOMACRO, an interactive Go interpreter with macros <https://github.com/cosmos72/gomacro>
-// Copyright (C) 2017-2019 Massimiliano Ghilardi
-// License MPL v2.0+: Mozilla Public License version 2.0 or later <http://mozilla.org/MPL/2.0/>
-// This is free software with ABSOLUTELY NO WARRANTY.
-//
-// Type %chelp for help
-`, g.ReplCmdChar)
+		fmt.Fprintf(ir.Stdout, `Go version %s (%s, %s)
+Type %ccopyright or %clicense for more information
+GOMACRO ---- interactive Go interpreter with generics and macros
+
+Type %chelp for help
+
+`, g.GoVersion, g.GoOS, g.GoArch, g.ReplCmdChar, g.ReplCmdChar, g.ReplCmdChar)
 	}
 	tty, _ := MakeTtyReadline(historyfile)
 	defer tty.Close(historyfile) // restore normal tty mode

--- a/fast/cmd.go
+++ b/fast/cmd.go
@@ -266,15 +266,22 @@ func (cmds Cmds) ShowHelp(g *base.Globals) {
 	g.Fprintf(out, "%s", "// abbreviations are allowed if unambiguous.\n")
 }
 
+func (cmds Cmds) ShowMessage(g *base.Globals, msg string) {
+	out := g.Stdout
+	g.Fprintf(out, "%s", msg)
+}
+
 var Commands Cmds
 
 func init() {
 	Commands.m = map[byte][]Cmd{
+		'c': []Cmd{{"copyright", (*Interp).cmdCopyright, `copyright        show copyright`}},
 		'd': []Cmd{{"debug", (*Interp).cmdDebug, `debug EXPR        debug expression or statement interactively`}},
 		'e': []Cmd{{"env", (*Interp).cmdEnv, `env [NAME]        show available functions, variables and constants
                    in current package, or from imported package NAME`}},
 		'h': []Cmd{{"help", (*Interp).cmdHelp, `help              show this help`}},
 		'i': []Cmd{{"inspect", (*Interp).cmdInspect, `inspect EXPR      inspect expression interactively`}},
+		'l': []Cmd{{"license", (*Interp).cmdLicense, `license        show license`}},
 		'o': []Cmd{{"options", (*Interp).cmdOptions, `options [OPTS]    show or toggle interpreter options`}},
 		'p': []Cmd{{"package", (*Interp).cmdPackage, `package "PKGPATH" switch to package PKGPATH, importing it if possible`}},
 		'q': []Cmd{{"quit", (*Interp).cmdQuit, `quit              quit the interpreter`}},
@@ -334,6 +341,18 @@ func (ir *Interp) cmdEnv(arg string, opt base.CmdOpt) (string, base.CmdOpt) {
 
 func (ir *Interp) cmdHelp(arg string, opt base.CmdOpt) (string, base.CmdOpt) {
 	Commands.ShowHelp(&ir.Comp.Globals)
+	return "", opt
+}
+
+func (ir *Interp) cmdCopyright(arg string, opt base.CmdOpt) (string, base.CmdOpt) {
+	copyright := "Copyright (C) 2018-2019 Massimiliano Ghilardi <https://github.com/cosmos72/gomacro>\nThis is free software with ABSOLUTELY NO WARRANTY.\n"
+	Commands.ShowMessage(&ir.Comp.Globals, copyright)
+	return "", opt
+}
+
+func (ir *Interp) cmdLicense(arg string, opt base.CmdOpt) (string, base.CmdOpt) {
+	license := "License MPL v2.0+: Mozilla Public License version 2.0 or later <http://mozilla.org/MPL/2.0/>\n"
+	Commands.ShowMessage(&ir.Comp.Globals, license)
 	return "", opt
 }
 

--- a/fast/interpreter.go
+++ b/fast/interpreter.go
@@ -60,7 +60,7 @@ func newTopInterp(path string) *Interp {
 		KnownImports: make(map[string]*Import),
 		interf2proxy: make(map[r.Type]r.Type),
 		proxy2interf: make(map[r.Type]xr.Type),
-		Prompt:       "gomacro> ",
+		Prompt:       "gomacro [In]: ",
 		Jit:          NewJit(),
 	}
 

--- a/fast/repl.go
+++ b/fast/repl.go
@@ -260,13 +260,13 @@ func (ir *Interp) ReplStdin() {
 	g := ir.Comp.CompGlobals
 
 	if g.Options&OptShowPrompt != 0 {
-		g.Fprintf(g.Stdout, `// GOMACRO, an interactive Go interpreter with generics and macros
-// Copyright (C) 2018-2019 Massimiliano Ghilardi <https://github.com/cosmos72/gomacro>
-// License MPL v2.0+: Mozilla Public License version 2.0 or later <http://mozilla.org/MPL/2.0/>
-// This is free software with ABSOLUTELY NO WARRANTY.
-//
-// Type %chelp for help
-`, g.ReplCmdChar)
+		g.Fprintf(g.Stdout, `Go version %s (%s, %s)
+Type %ccopyright or %clicense for more information
+GOMACRO ---- interactive Go interpreter with generics and macros
+
+Type %chelp for help
+
+`, g.GoVersion, g.GoOS, g.GoArch, g.ReplCmdChar, g.ReplCmdChar, g.ReplCmdChar)
 	}
 	tty, _ := MakeTtyReadline(historyfile)
 	defer tty.Close(historyfile) // restore normal tty mode


### PR DESCRIPTION
I would like to propose `gomacro` prompts to more like `ipython` shell prompt

```
Go version go1.12.6 (linux, amd64)
Type :copyright or :license for more information
GOMACRO ---- interactive Go interpreter with generics and macros

Type :help for help

gomacro [In]: 
```