### PR TITLE
Support flattening AstWithSlice on Append

### DIFF
--- a/ast2/ast_slice.go
+++ b/ast2/ast_slice.go
@@ -87,7 +87,7 @@ func (x SpecSlice) Slice(lo, hi int) AstWithSlice  { x.X = x.X[lo:hi]; return x 
 func (x StmtSlice) Slice(lo, hi int) AstWithSlice  { x.X = x.X[lo:hi]; return x }
 
 func (x AstSlice) Append(child Ast) AstWithSlice   { x.X = append(x.X, child); return x }
-func (x NodeSlice) Append(child Ast) AstWithSlice  { x.X = append(x.X, ToNode(child)); return x }
+func (x NodeSlice) Append(child Ast) AstWithSlice  { x.X = ToNodesAppend(x.X, child); return x }
 func (x ExprSlice) Append(child Ast) AstWithSlice  { x.X = append(x.X, ToExpr(child)); return x }
 func (x FieldSlice) Append(child Ast) AstWithSlice { x.X = append(x.X, ToField(child)); return x }
 func (x DeclSlice) Append(child Ast) AstWithSlice  { x.X = append(x.X, ToDecl(child)); return x }


### PR DESCRIPTION
Prior to the change, the Append method of NodeSlice would panic if the
child satified AstWithSlice itself.  The panic originates from the
ToNode call, since none of the AstWithSlice types also satify
AstWithNode.

This change simply makes a call to ToNodesAppend instead of append.
ToNodesAppend already checks for AstWithSlice and will unwrap the
children.  Thus this allows one to append a slice into another slice,
resulting in one flat slice.

This is in an attempt to fix #69, but instead gomacro appears to hang:

```
$ gomacro -vv -f -w -m issue.gomacro
// debug: MacroExpandCodewalk: qq = 0, macroexpanding [import (
	"go/ast"
)]
// debug: MacroExpand1: found list: [import (
	"go/ast"
)]
// debug: MacroExpandCodewalk: qq = 0, recursing on [import (
	"go/ast"
)]
```

Not sure what's going on...