### PR TITLE
Ensure genimport has a name under ImInception mode

### DIFF
--- a/base/genimport/genimport.go
+++ b/base/genimport/genimport.go
@@ -77,6 +77,7 @@ func newGenImport(o *Output, out *bytes.Buffer, path string, gpkg *types.Package
 
 	if mode == ImInception {
 		gen.reflect = "r."
+		gen.name = packageSanitizedName(gen.path)
 	}
 	if mode == ImPlugin {
 		gen.proxyprefix = "P_"


### PR DESCRIPTION
Prior to this change, the previous commit to base/genimport/genimport.go (30b1253a) removed assigning a name to the genimport struct in the newGenImport function.  This name is essential when the ImInception mode is used, without it the generated `x_package.go` file has an incomplete package statement (i.e. the package name is missing).  This leads to invalid code being generated.

This change reintroduces the assignment to genimport's name within the newGenImport function.  The assignment only occurs under the ImInception mode.  I assume that the collectPackageImportsWithRename function is sufficient for the other modes.