### PR TITLE
Update README to show global installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The following combinations are tested and known to work:
 
   The command
   ```
-  go get -u github.com/cosmos72/gomacro
+  go install github.com/cosmos72/gomacro@latest
   ```
   downloads, compiles and installs gomacro and its dependencies
 


### PR DESCRIPTION
Unsure if this fits with the goal of the project but using `go install` in the instructions makes for a better development experience since one can run this anywhere to get started.

Definitely an opinion only though, thanks for the project!