### PR TITLE
move history file to `$XDG_STATE_HOME` on unix

### DIFF
--- a/base/paths/paths.go
+++ b/base/paths/paths.go
@@ -69,6 +69,25 @@ func UserHomeDir() string {
 	return unixpath(home)
 }
 
+// returns path to gomacro's history file
+// If $HOME/.gomacro_history can be opened, or
+// $XDG_STATE_HOME can not be opened, returns $HOME/.gomacro_history
+// Otherwise returns $XDG_STATE_HOME/gomacro_history
+func HistoryFile() string {
+	home := UserHomeDir()
+	historydir := os.Getenv("XDG_STATE_HOME")
+	if len(historydir) == 0 {
+		historydir = Subdir(home, ".local", "state")
+	}
+	historyfile := Subdir(home, ".gomacro_history")
+	if _, err := os.Stat(historyfile); err != nil {
+		if _, err := os.Stat(historydir); err == nil {
+			historyfile = Subdir(historydir, "gomacro_history")
+		}
+	}
+	return historyfile
+}
+
 func Subdir(dirs ...string) string {
 	// should use string(os.PathSeparator) instead of "/', but:
 	// 1) package names use '/', not os.PathSeparator

--- a/base/paths/x_package.go
+++ b/base/paths/x_package.go
@@ -21,6 +21,7 @@ func init() {
 			"Subdir":                   r.ValueOf(Subdir),
 			"SymbolFromImportsPackage": r.ValueOf(&SymbolFromImportsPackage).Elem(),
 			"UserHomeDir":              r.ValueOf(UserHomeDir),
+			"HistoryFile":              r.ValueOf(HistoryFile),
 		},
 	}
 }

--- a/classic/interpreter.go
+++ b/classic/interpreter.go
@@ -44,7 +44,7 @@ func (ir *Interp) ChangePackage(path string) {
 	ir.Env = ir.Env.ChangePackage(path)
 }
 
-var historyfile = paths.Subdir(paths.UserHomeDir(), ".gomacro_history")
+var historyfile = paths.HistoryFile()
 
 func (ir *Interp) ReplStdin() {
 	g := ir.Globals

--- a/fast/repl.go
+++ b/fast/repl.go
@@ -254,7 +254,7 @@ func (ir *Interp) prepareEnv(minValDelta int, minIntDelta int) *Env {
 
 // ====================== Repl() and friends =====================
 
-var historyfile = paths.Subdir(paths.UserHomeDir(), ".gomacro_history")
+var historyfile = paths.HistoryFile()
 
 func (ir *Interp) ReplStdin() {
 	g := ir.Comp.CompGlobals


### PR DESCRIPTION
Move history file to `$XDG_STATE_HOME` per [XDG Base Directory
Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
, which provides guides for organization of hidden files and has been
commonly adopted among unix-like systems[^1].

However, to avoid break existing workflow, `$HOME/.gomacro_history`
will be prefered if it has been found.

---

[^1]: https://wiki.archlinux.org/title/XDG_Base_Directory
